### PR TITLE
Fix Flask package path resolution to serve React dashboard at base URL

### DIFF
--- a/local_weather_server/server/app.py
+++ b/local_weather_server/server/app.py
@@ -16,7 +16,7 @@ from local_weather_server.server.servlets.default import default
 from local_weather_server.server.servlets.wunderground import wunderground
 
 app = flask.Flask(
-    'local weather server',
+    __name__,
     static_folder='static', static_url_path='',
 )
 app.logger.removeHandler(default_handler)


### PR DESCRIPTION
- Swapped the hardcoded Flask app name string for __name__.
- Allows Flask to correctly resolve the server/static/ directory inside the Docker container.
- Ensures the base URL serves the frontend index.html instead of falling back to the API success JSON.