### PR TITLE
Include all static dashboard assets in setup.cfg package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,8 +36,8 @@ console_scripts =
 local_weather_server =
     schema/*/*.sql
 local_weather_server.server =
-    static/css/*.css
-    static/js/*.js
+    static/*
+    static/*/*
 
 [bdist_wheel]
 universal = True


### PR DESCRIPTION
- Updated options.package_data for local_weather_server.server to copy static/* and static/*/* recursively.

- Ensures that index.html and its nested assets are correctly bundled by setuptools when pip install is run inside the Docker image.